### PR TITLE
Ignore pytest cache in markdownlint config

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,14 +1,27 @@
 {
   "config": {
-    "MD004": { "style": "dash" },
-    "MD010": { "code_blocks": false },
+    "MD004": {
+      "style": "dash"
+    },
+    "MD010": {
+      "code_blocks": false
+    },
     "MD013": {
       "line_length": 80,
       "code_block_line_length": 120,
       "tables": false,
       "headings": false
     },
-    "MD029": { "style": "ordered" }
+    "MD029": {
+      "style": "ordered"
+    }
   },
-  "ignores": ["**/.git/**", "**/.venv/**", ".node_modules/**", "**/node_modules/**", "**/target/**"]
+  "ignores": [
+    "**/.git/**",
+    "**/.venv/**",
+    ".node_modules/**",
+    "**/node_modules/**",
+    "**/target/**",
+    "**/.pytest_cache/**"
+  ]
 }

--- a/docs/polythene-design.md
+++ b/docs/polythene-design.md
@@ -7,8 +7,8 @@ inside environments with differing levels of privilege and isolation. The
 Cyclopts-based CLI coordinates root file system staging, command execution, and
 log reporting so that the same test suite can be executed in restrictive
 sandboxes such as the Codex cloud and in container-friendly continuous
-integration (CI) runners. This document records the architectural structure that
-enables that behaviour and captures the trade-offs behind the current
+integration (CI) runners. This document records the architectural structure
+that enables that behaviour and captures the trade-offs behind the current
 implementation.
 
 ## Execution flow

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -144,5 +144,5 @@ Adjust the predicate to match your retention policy.
 
 ## Further reading
 
-Refer to `polythene/__init__.py` for the Cyclopts application definition
-and to `tests/test_polythene.py` for integration-style usage examples.
+Refer to `polythene/__init__.py` for the Cyclopts application definition and to
+`tests/test_polythene.py` for integration-style usage examples.


### PR DESCRIPTION
## Summary
- add the pytest cache directory to the markdownlint ignore list to prevent lint runs from scanning cached test data
- reflow documentation lines touched by markdownlint formatting

## Testing
- make fmt

------
https://chatgpt.com/codex/tasks/task_e_68e04e1f1c488322b30ee90cc1feb108