### PR TITLE
Fix CI pytest target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
           uv pip install slipcover pytest-forked
           uv run python -m slipcover \
             --source=./polythene \
-            --omit="*/unittests/*,*/.venv/*" \
+            --omit="*/tests/*,*/.venv/*" \
             --branch \
             --out coverage.xml \
-            -m pytest --forked -v polythene/unittests
+            -m pytest --forked -v tests
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4

--- a/polythene/unittests/README.md
+++ b/polythene/unittests/README.md
@@ -1,6 +1,5 @@
 # Legacy test placeholder
 
-The shared-actions CI harness still passes ``polythene/unittests`` to pytest
-when exercising Slipcover-based coverage.  The actual tests now live under the
-``tests/`` directory, so this placeholder directory simply ensures that the
-legacy path continues to resolve without errors.
+The test suite moved to the top-level ``tests/`` package, but this legacy
+directory remains so historical references to ``polythene/unittests`` continue
+to resolve.  New tooling should invoke pytest against ``tests/`` directly.


### PR DESCRIPTION
## Summary
- point the CI pytest invocation at the real tests/ directory
- align the coverage omit list with the new test location

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e27b3664dc832280492cce81b2631b

## Summary by Sourcery

Fix CI pytest invocation and coverage omit patterns to target the top-level tests directory, and update the legacy unittests README accordingly

Bug Fixes:
- Fix CI pytest invocation to point at the top-level tests directory

CI:
- Update coverage omit patterns to exclude the tests directory instead of the legacy unittests path

Documentation:
- Revise legacy unittests README to reflect the new test location and usage