### PR TITLE
Fix proot backend login shell invocation

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -93,11 +93,11 @@ Each backend receives the prepared filesystem as its root and blocks network
 access. If none of the backends is available, the command fails with an error
 message detailing the missing tooling.
 
-When a specific backend is preferable, pass `--isolation <backend>`
-(or the equivalent `--isolation=<backend>` form) to reorder the probing
-sequence. GitHub runners lack user namespace support for `bwrap`, and
-specifying `--isolation proot` avoids the noisy permission errors emitted
-by bubblewrap before `proot` succeeds.
+When a specific backend is preferable, pass `--isolation <backend>` (or the
+equivalent `--isolation=<backend>` form) to reorder the probing sequence.
+GitHub runners lack user namespace support for `bwrap`, and specifying
+`--isolation proot` avoids the noisy permission errors emitted by bubblewrap
+before `proot` succeeds.
 
 Because the same UUID works across hosts, you can prepare an image on Codex and
 reuse it on CI:

--- a/polythene/backends.py
+++ b/polythene/backends.py
@@ -169,7 +169,7 @@ def _prepare_bwrap(
         "--chdir",
         "/",
         "/bin/sh",
-        "-lc",
+        "-c",
         inner_cmd,
     ]
 

--- a/polythene/backends.py
+++ b/polythene/backends.py
@@ -187,7 +187,7 @@ def _prepare_proot(
         run_cmd(proot[tuple(probe_args)], fg=True, timeout=timeout)
     except (ProcessExecutionError, SystemExit, OSError):
         return None
-    return ["-R", str(root), "-0", "/bin/sh", "-lc", inner_cmd]
+    return ["-R", str(root), "-0", "/bin/sh", "-c", inner_cmd]
 
 
 def _prepare_chroot(

--- a/tests/bdd/test_cli_behaviour.py
+++ b/tests/bdd/test_cli_behaviour.py
@@ -10,11 +10,23 @@ import pytest
 from conftest import CliResult
 from pytest_bdd import given, parsers, scenarios, then, when
 
+import polythene.backends as backend_module
 import polythene.isolation as isolation
 
 Context = dict[str, object]
 
 scenarios("../features/polythene_cli.feature")
+
+
+class _RecordingCommand:
+    """Capture proot invocations to assert shell arguments."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    def __getitem__(self, args: tuple[str, ...]) -> tuple[str, ...]:
+        self.calls.append(args)
+        return args
 
 
 @pytest.fixture
@@ -28,6 +40,13 @@ def clean_store(tmp_path: Path, cli_context: Context) -> Path:
     """Record the temporary directory used to store exported rootfs trees."""
     cli_context["store"] = tmp_path
     return tmp_path
+
+
+@given(parsers.parse('the rootfs "{uuid}" exists'))
+def ensure_rootfs(cli_context: Context, uuid: str) -> None:
+    """Create a rootfs directory for ``uuid`` inside the store."""
+    store = Path(cli_context["store"])
+    (store / uuid).mkdir(parents=True, exist_ok=True)
 
 
 @given(parsers.parse('UUID generation returns "{value}"'))
@@ -44,6 +63,32 @@ def stub_export(monkeypatch: pytest.MonkeyPatch) -> None:
         dest.mkdir(parents=True, exist_ok=True)
 
     monkeypatch.setattr(isolation, "export_rootfs", _fake)
+
+
+@given("proot execution is stubbed")
+def stub_proot(monkeypatch: pytest.MonkeyPatch, cli_context: Context) -> None:
+    """Limit execution to proot and record its invocations."""
+    proot_backend = next(
+        backend
+        for backend in backend_module.create_backends()
+        if backend.name == "proot"
+    )
+    stub = _RecordingCommand()
+    executions: list[tuple[str, ...]] = []
+
+    def fake_get_command(binary: str) -> _RecordingCommand:
+        assert binary == proot_backend.binary
+        return stub
+
+    def fake_run_cmd(cmd: tuple[str, ...], *, fg: bool, timeout: int | None) -> int:
+        executions.append(cmd)
+        return 0
+
+    monkeypatch.setattr(isolation, "BACKENDS", (proot_backend,))
+    monkeypatch.setattr(backend_module, "get_command", fake_get_command)
+    monkeypatch.setattr(backend_module, "run_cmd", fake_run_cmd)
+    cli_context["proot_stub"] = stub
+    cli_context["proot_executions"] = executions
 
 
 @when(parsers.parse('I run the CLI with arguments "{raw}"'))
@@ -101,3 +146,18 @@ def assert_rootfs_exists(cli_context: Context, uuid: str) -> None:
     """Ensure the exported rootfs folder exists on disk."""
     store = Path(cli_context["store"])
     assert (store / uuid).is_dir()
+
+
+@then("proot ran without requesting a login shell")
+def assert_proot_non_login(cli_context: Context) -> None:
+    """Verify that the stubbed proot invocation avoids ``-lc``."""
+    stub = cli_context.get("proot_stub")
+    executions = cli_context.get("proot_executions")
+    assert isinstance(stub, _RecordingCommand)
+    assert isinstance(executions, list)
+    assert stub.calls == executions
+    assert len(stub.calls) == 2
+    probe_call, exec_call = stub.calls
+    assert probe_call[-2:] == ("-c", "true")
+    assert exec_call[-2] == "-c"
+    assert exec_call[-1] == "true"

--- a/tests/features/polythene_cli.feature
+++ b/tests/features/polythene_cli.feature
@@ -22,3 +22,11 @@ Feature: Polythene CLI interactions
     When I run the CLI with arguments "exec missing --store {store} -- true"
     Then the CLI exits with code 1
     And stderr contains "No such UUID rootfs"
+
+  Scenario: Executing via proot avoids login shell side effects
+    Given a clean store directory
+    And the rootfs "uuid-proot" exists
+    And proot execution is stubbed
+    When I run the CLI with arguments "exec uuid-proot --store {store} -- true"
+    Then the CLI exits with code 0
+    And proot ran without requesting a login shell

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,72 @@
+"""Tests for sandbox execution backends."""
+
+from __future__ import annotations
+
+import pathlib
+import typing as typ
+
+import pytest
+
+from polythene import backends
+
+if typ.TYPE_CHECKING:
+    from plumbum.commands.base import BaseCommand
+else:  # pragma: no cover - runtime sentinel for typing-only import
+    BaseCommand = typ.Any  # type: ignore[assignment]
+
+
+class _StubCommand:
+    """Record invocations made by ``plumbum`` style command objects."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    def __getitem__(self, args: tuple[str, ...]) -> tuple[str, ...]:
+        self.calls.append(args)
+        return args
+
+
+def test_prepare_proot_avoids_login_shell(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_prepare_proot`` should not request a login shell.
+
+    Login shells source profile scripts, which can mutate environment state in
+    unexpected ways.  The probe command already uses ``-c`` so the execution
+    command should mirror it to ensure a consistent environment.
+    """
+    assert isinstance(tmp_path, pathlib.Path)
+    assert isinstance(monkeypatch, pytest.MonkeyPatch)
+    stub = _StubCommand()
+
+    def fake_run_cmd(cmd: tuple[str, ...], *, fg: bool, timeout: int | None) -> int:
+        return 0
+
+    monkeypatch.setattr(backends, "run_cmd", fake_run_cmd)
+
+    inner_cmd = "test -x /usr/bin/rust-toy-app"
+    result = backends._prepare_proot(
+        typ.cast("BaseCommand", stub),
+        tmp_path,
+        inner_cmd,
+        lambda _msg: None,
+        timeout=None,
+        _container_tmp=tmp_path,
+    )
+
+    assert stub.calls[0] == (
+        "-R",
+        str(tmp_path),
+        "-0",
+        "/bin/sh",
+        "-c",
+        "true",
+    )
+    assert result == [
+        "-R",
+        str(tmp_path),
+        "-0",
+        "/bin/sh",
+        "-c",
+        inner_cmd,
+    ]


### PR DESCRIPTION
## Summary
- stop the proot backend from invoking /bin/sh as a login shell so the sandbox keeps the expected PATH
- add a regression test that checks the generated proot command mirrors the non-login probe arguments

## Testing
- make check-fmt
- make lint
- make typecheck
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e663ceae5c8322ae45b0d7ccfdb77c

## Summary by Sourcery

Stop using a login shell in the proot backend to preserve the intended environment and add a regression test for the updated command invocation

Bug Fixes:
- Use '-c' instead of '-lc' when invoking /bin/sh in the proot backend to avoid a login shell

Tests:
- Add a regression test for _prepare_proot to verify the command arguments mirror the probe invocation without sourcing login profiles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed shell invocation so sandboxed executions avoid a login shell, preventing unintended profile/environment side effects and improving reliability.

- Tests
  - Added unit and end-to-end tests that record and assert shell invocation behavior for sandbox backends, increasing coverage and preventing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->