### PR TITLE
Handle bubblewrap permission failures

### DIFF
--- a/polythene/backends.py
+++ b/polythene/backends.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses as dc
 import errno
+import os
 import typing as typ
 from pathlib import Path
 
@@ -37,6 +38,16 @@ _BWRAP_SYSCTL_DISABLED = (
     "bubblewrap requires unprivileged user namespaces; falling back to proot"
 )
 _BWRAP_PERMISSION_DENIED = "unprivileged user namespaces disabled"
+
+
+def _is_privileged_user() -> bool:
+    """Return ``True`` when the current process is allowed privileged actions."""
+    # ``geteuid`` is not available on Windows, but Polythene only targets Linux.
+    # Guard in case someone executes the tests elsewhere.
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is None:
+        return False
+    return geteuid() == 0
 
 
 def _is_bwrap_perm_error(exc: Exception) -> bool:
@@ -115,15 +126,16 @@ def _probe_bwrap_userns(
     timeout: int | None,
     logger: Logger,
 ) -> list[str]:
-    try:
-        value = _UNPRIVILEGED_USERNS_PATH.read_text(encoding="utf-8").strip()
-    except FileNotFoundError:
-        pass
-    except OSError as exc:
-        logger(f"Unable to read /proc/sys/kernel/unprivileged_userns_clone: {exc}")
-    else:
-        if value == "0":
-            raise BubblewrapUnavailable(_BWRAP_SYSCTL_DISABLED)
+    if not _is_privileged_user():
+        try:
+            value = _UNPRIVILEGED_USERNS_PATH.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger(f"Unable to read /proc/sys/kernel/unprivileged_userns_clone: {exc}")
+        else:
+            if value == "0":
+                raise BubblewrapUnavailable(_BWRAP_SYSCTL_DISABLED)
 
     try:
         run_cmd(

--- a/polythene/backends.py
+++ b/polythene/backends.py
@@ -39,6 +39,25 @@ _BWRAP_SYSCTL_DISABLED = (
 _BWRAP_PERMISSION_DENIED = "unprivileged user namespaces disabled"
 
 
+def _is_bwrap_perm_error(exc: Exception) -> bool:
+    """Return ``True`` when ``exc`` indicates user namespace permissions."""
+    if isinstance(exc, ProcessExecutionError):
+        stderr = exc.stderr
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode(errors="ignore")
+        else:
+            stderr = stderr or ""
+        errno_value = getattr(exc, "errno", None)
+        if "Permission denied" in stderr:
+            return True
+        return "Permission denied" in str(exc) or errno_value == errno.EPERM
+
+    if isinstance(exc, OSError):
+        return exc.errno == errno.EPERM
+
+    return False
+
+
 @dc.dataclass(slots=True, frozen=True)
 class Backend:
     """Descriptor for an execution backend."""
@@ -61,14 +80,21 @@ class Backend:
         """Probe and run the backend, returning the chosen name and exit status."""
         try:
             tool = get_command(self.binary)
-        except SystemExit:
+        except SystemExit as exc:
+            logger(f"{self.name} unavailable: {exc}")
             return None
 
         if self.ensure_dirs:
             ensure_runtime_paths(root)
 
-        args = self.prepare(tool, root, inner_cmd, logger, timeout, container_tmp)
+        try:
+            args = self.prepare(tool, root, inner_cmd, logger, timeout, container_tmp)
+        except BubblewrapUnavailable as exc:
+            logger(str(exc))
+            return None
+
         if args is None:
+            logger(f"{self.name} unavailable during preparation")
             return None
 
         logger(f"Executing via {self.name}")
@@ -117,18 +143,12 @@ def _probe_bwrap_userns(
             fg=True,
             timeout=timeout,
         )
-    except (ProcessExecutionError, SystemExit, OSError) as exc:
-        if isinstance(exc, ProcessExecutionError):
-            stderr = exc.stderr or ""
-            if isinstance(stderr, bytes):
-                stderr = stderr.decode(errors="ignore")
-            errno_value = getattr(exc, "errno", None)
-            if "Permission denied" in str(stderr) or errno_value == errno.EPERM:
-                raise BubblewrapUnavailable(_BWRAP_PERMISSION_DENIED) from exc
-        if isinstance(exc, OSError) and exc.errno == errno.EPERM:
+    except (ProcessExecutionError, OSError) as exc:
+        if _is_bwrap_perm_error(exc):
             raise BubblewrapUnavailable(_BWRAP_PERMISSION_DENIED) from exc
         logger(f"User namespace probe failed: {exc}")
         return []
+
     return ["--unshare-user", "--uid", "0", "--gid", "0"]
 
 
@@ -163,11 +183,7 @@ def _prepare_bwrap(
     timeout: int | None,
     container_tmp: Path,
 ) -> list[str] | None:
-    try:
-        base_flags = _probe_bwrap_userns(bwrap, timeout=timeout, logger=logger)
-    except BubblewrapUnavailable as exc:
-        logger(str(exc))
-        return None
+    base_flags = _probe_bwrap_userns(bwrap, timeout=timeout, logger=logger)
     base_flags.extend(["--unshare-pid", "--unshare-ipc", "--unshare-uts"])
     proc_flags = _probe_bwrap_proc(bwrap, base_flags, root, timeout=timeout)
     probe_args = [

--- a/polythene/backends.py
+++ b/polythene/backends.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses as dc
+import errno
 import typing as typ
 from pathlib import Path
 
@@ -14,6 +15,7 @@ from .script_utils import ensure_directory, get_command
 
 __all__ = [
     "Backend",
+    "BubblewrapUnavailable",
     "create_backends",
     "ensure_runtime_paths",
 ]
@@ -24,6 +26,17 @@ Logger = typ.Callable[[str], None]
 PrepareFn = typ.Callable[
     [BaseCommand, Path, str, Logger, int | None, Path], list[str] | None
 ]
+
+
+class BubblewrapUnavailable(RuntimeError):  # noqa: N818 - aligns with CLI wording
+    """Raised when the host kernel forbids bubblewrap user namespaces."""
+
+
+_UNPRIVILEGED_USERNS_PATH = Path("/proc/sys/kernel/unprivileged_userns_clone")
+_BWRAP_SYSCTL_DISABLED = (
+    "bubblewrap requires unprivileged user namespaces; falling back to proot"
+)
+_BWRAP_PERMISSION_DENIED = "unprivileged user namespaces disabled"
 
 
 @dc.dataclass(slots=True, frozen=True)
@@ -44,8 +57,8 @@ class Backend:
         timeout: int | None,
         logger: Logger,
         container_tmp: Path,
-    ) -> int | None:
-        """Probe and run the backend, returning the exit status."""
+    ) -> tuple[str, int] | None:
+        """Probe and run the backend, returning the chosen name and exit status."""
         try:
             tool = get_command(self.binary)
         except SystemExit:
@@ -60,7 +73,8 @@ class Backend:
 
         logger(f"Executing via {self.name}")
         result = run_cmd(tool[tuple(args)], fg=True, timeout=timeout)
-        return int(result) if result is not None else 0
+        exit_code = int(result) if result is not None else 0
+        return (self.name, exit_code)
 
 
 def ensure_runtime_paths(root: Path) -> None:
@@ -75,6 +89,16 @@ def _probe_bwrap_userns(
     timeout: int | None,
     logger: Logger,
 ) -> list[str]:
+    try:
+        value = _UNPRIVILEGED_USERNS_PATH.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger(f"Unable to read /proc/sys/kernel/unprivileged_userns_clone: {exc}")
+    else:
+        if value == "0":
+            raise BubblewrapUnavailable(_BWRAP_SYSCTL_DISABLED)
+
     try:
         run_cmd(
             bwrap[
@@ -94,6 +118,15 @@ def _probe_bwrap_userns(
             timeout=timeout,
         )
     except (ProcessExecutionError, SystemExit, OSError) as exc:
+        if isinstance(exc, ProcessExecutionError):
+            stderr = exc.stderr or ""
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode(errors="ignore")
+            errno_value = getattr(exc, "errno", None)
+            if "Permission denied" in str(stderr) or errno_value == errno.EPERM:
+                raise BubblewrapUnavailable(_BWRAP_PERMISSION_DENIED) from exc
+        if isinstance(exc, OSError) and exc.errno == errno.EPERM:
+            raise BubblewrapUnavailable(_BWRAP_PERMISSION_DENIED) from exc
         logger(f"User namespace probe failed: {exc}")
         return []
     return ["--unshare-user", "--uid", "0", "--gid", "0"]
@@ -130,7 +163,11 @@ def _prepare_bwrap(
     timeout: int | None,
     container_tmp: Path,
 ) -> list[str] | None:
-    base_flags = _probe_bwrap_userns(bwrap, timeout=timeout, logger=logger)
+    try:
+        base_flags = _probe_bwrap_userns(bwrap, timeout=timeout, logger=logger)
+    except BubblewrapUnavailable as exc:
+        logger(str(exc))
+        return None
     base_flags.extend(["--unshare-pid", "--unshare-ipc", "--unshare-uts"])
     proc_flags = _probe_bwrap_proc(bwrap, base_flags, root, timeout=timeout)
     probe_args = [

--- a/polythene/isolation.py
+++ b/polythene/isolation.py
@@ -280,6 +280,12 @@ def cmd_exec(
         except ProcessExecutionError as exc:
             raise SystemExit(_normalise_retcode(exc.retcode)) from exc
         if outcome is None:
+            warning = (
+                "Warning: backend.run returned None for backend "
+                f"'{backend.name}'. This may indicate an error or an "
+                "unsupported condition."
+            )
+            log(warning)
             next_backend = _next_available_backend(index + 1)
             if next_backend is not None:
                 source = current_isolation or backend.name

--- a/polythene/isolation.py
+++ b/polythene/isolation.py
@@ -257,11 +257,20 @@ def cmd_exec(
         remaining = [backend for backend in BACKENDS if backend is not preferred]
         selected_backends = (preferred, *remaining)
 
-    for backend in selected_backends:
+    def _next_available_backend(start: int) -> Backend | None:
+        for candidate in selected_backends[start:]:
+            if candidate.requires_root and not IS_ROOT:
+                continue
+            return candidate
+        return None
+
+    current_isolation = isolation
+
+    for index, backend in enumerate(selected_backends):
         if backend.requires_root and not IS_ROOT:
             continue
         try:
-            rc = backend.run(
+            outcome = backend.run(
                 root,
                 inner_cmd,
                 timeout=timeout,
@@ -270,6 +279,18 @@ def cmd_exec(
             )
         except ProcessExecutionError as exc:
             raise SystemExit(_normalise_retcode(exc.retcode)) from exc
+        if outcome is None:
+            next_backend = _next_available_backend(index + 1)
+            if next_backend is not None:
+                source = current_isolation or backend.name
+                log(f"{source} unavailable: falling back to {next_backend.name}")
+                current_isolation = next_backend.name
+            else:
+                current_isolation = backend.name
+            continue
+
+        name, rc = outcome
+        current_isolation = name
         if rc is not None:
             if rc == 0:
                 return

--- a/polythene/isolation.py
+++ b/polythene/isolation.py
@@ -280,12 +280,6 @@ def cmd_exec(
         except ProcessExecutionError as exc:
             raise SystemExit(_normalise_retcode(exc.retcode)) from exc
         if outcome is None:
-            warning = (
-                "Warning: backend.run returned None for backend "
-                f"'{backend.name}'. This may indicate an error or an "
-                "unsupported condition."
-            )
-            log(warning)
             next_backend = _next_available_backend(index + 1)
             if next_backend is not None:
                 source = current_isolation or backend.name
@@ -293,7 +287,6 @@ def cmd_exec(
                 current_isolation = next_backend.name
             else:
                 log(f"{backend.name} unavailable and no further backends remain")
-                current_isolation = backend.name
             continue
 
         name, rc = outcome

--- a/polythene/isolation.py
+++ b/polythene/isolation.py
@@ -286,6 +286,7 @@ def cmd_exec(
                 log(f"{source} unavailable: falling back to {next_backend.name}")
                 current_isolation = next_backend.name
             else:
+                log(f"{backend.name} unavailable and no further backends remain")
                 current_isolation = backend.name
             continue
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -160,6 +160,7 @@ def test_probe_bwrap_userns_respects_sysctl(
     flag = tmp_path / "unprivileged_userns_clone"
     flag.write_text("0", encoding="utf-8")
     monkeypatch.setattr(backends, "_UNPRIVILEGED_USERNS_PATH", flag)
+    monkeypatch.setattr(backends, "_is_privileged_user", lambda: False)
 
     def fail_run_cmd(*_args: object, **_kwargs: object) -> int:
         pytest.fail("bubblewrap should not be probed when sysctl=0")
@@ -173,6 +174,34 @@ def test_probe_bwrap_userns_respects_sysctl(
             timeout=None,
             logger=lambda _msg: None,
         )
+
+
+def test_probe_bwrap_userns_skips_sysctl_for_privileged(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Root users ignore the sysctl and still probe bubblewrap."""
+    flag = tmp_path / "unprivileged_userns_clone"
+    flag.write_text("0", encoding="utf-8")
+    monkeypatch.setattr(backends, "_UNPRIVILEGED_USERNS_PATH", flag)
+    monkeypatch.setattr(backends, "_is_privileged_user", lambda: True)
+
+    stub = _StubCommand()
+    executed: list[tuple[str, ...]] = []
+
+    def fake_run_cmd(cmd: tuple[str, ...], *, fg: bool, timeout: int | None) -> int:
+        executed.append(cmd)
+        return 0
+
+    monkeypatch.setattr(backends, "run_cmd", fake_run_cmd)
+
+    result = backends._probe_bwrap_userns(
+        typ.cast("BaseCommand", stub),
+        timeout=None,
+        logger=lambda _msg: None,
+    )
+
+    assert result == ["--unshare-user", "--uid", "0", "--gid", "0"]
+    assert stub.calls == executed  # probe executed despite sysctl=0
 
 
 def test_backend_run_logs_bubblewrap_unavailability(

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -162,9 +162,8 @@ def test_probe_bwrap_userns_respects_sysctl(
     monkeypatch.setattr(backends, "_UNPRIVILEGED_USERNS_PATH", flag)
     monkeypatch.setattr(backends, "_is_privileged_user", lambda: False)
 
-    def fail_run_cmd(*_args: object, **_kwargs: object) -> typ.NoReturn:
+    def fail_run_cmd(*_args: object, **_kwargs: object) -> None:
         pytest.fail("bubblewrap should not be probed when sysctl=0")
-        raise AssertionError("unreachable")  # Keep Pyright happy
 
     monkeypatch.setattr(backends, "run_cmd", fail_run_cmd)
 
@@ -174,6 +173,68 @@ def test_probe_bwrap_userns_respects_sysctl(
             timeout=None,
             logger=lambda _msg: None,
         )
+
+
+def test_probe_bwrap_userns_sysctl_missing(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing sysctl files should not prevent probing."""
+    missing_path = tmp_path / "nonexistent"
+    monkeypatch.setattr(backends, "_UNPRIVILEGED_USERNS_PATH", missing_path)
+    monkeypatch.setattr(backends, "_is_privileged_user", lambda: False)
+
+    stub = _StubCommand()
+    executed: list[tuple[str, ...]] = []
+
+    def fake_run_cmd(cmd: tuple[str, ...], *, fg: bool, timeout: int | None) -> int:
+        executed.append(cmd)
+        return 0
+
+    monkeypatch.setattr(backends, "run_cmd", fake_run_cmd)
+
+    result = backends._probe_bwrap_userns(
+        typ.cast("BaseCommand", stub),
+        timeout=None,
+        logger=lambda _msg: None,
+    )
+
+    assert result == ["--unshare-user", "--uid", "0", "--gid", "0"]
+    assert executed == stub.calls
+
+
+def test_probe_bwrap_userns_sysctl_read_error(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unexpected sysctl read errors should be logged but probing continues."""
+    bad_path = tmp_path / "userns_dir"
+    bad_path.mkdir()
+    monkeypatch.setattr(backends, "_UNPRIVILEGED_USERNS_PATH", bad_path)
+    monkeypatch.setattr(backends, "_is_privileged_user", lambda: False)
+
+    stub = _StubCommand()
+    executed: list[tuple[str, ...]] = []
+    logs: list[str] = []
+
+    def fake_run_cmd(cmd: tuple[str, ...], *, fg: bool, timeout: int | None) -> int:
+        executed.append(cmd)
+        return 0
+
+    monkeypatch.setattr(backends, "run_cmd", fake_run_cmd)
+
+    result = backends._probe_bwrap_userns(
+        typ.cast("BaseCommand", stub),
+        timeout=None,
+        logger=logs.append,
+    )
+
+    assert result == ["--unshare-user", "--uid", "0", "--gid", "0"]
+    assert executed == stub.calls
+    assert logs == [
+        (
+            "Unable to read /proc/sys/kernel/unprivileged_userns_clone: "
+            f"[Errno 21] Is a directory: '{bad_path}'"
+        )
+    ]
 
 
 def test_probe_bwrap_userns_skips_sysctl_for_privileged(

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import typing as typ
 
 import pytest
@@ -136,6 +137,22 @@ def test_probe_bwrap_userns_permission_denied(monkeypatch: pytest.MonkeyPatch) -
         )
 
 
+def test_probe_bwrap_userns_oserror_eperm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OS errors reporting ``EPERM`` disable bubblewrap immediately."""
+
+    def fake_run_cmd(_cmd: tuple[str, ...], *, fg: bool, timeout: int | None) -> int:
+        raise OSError(errno.EPERM, "Operation not permitted")
+
+    monkeypatch.setattr(backends, "run_cmd", fake_run_cmd)
+
+    with pytest.raises(backends.BubblewrapUnavailable, match="unprivileged"):
+        backends._probe_bwrap_userns(
+            typ.cast("BaseCommand", _StubCommand()),
+            timeout=None,
+            logger=lambda _msg: None,
+        )
+
+
 def test_probe_bwrap_userns_respects_sysctl(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -146,6 +163,7 @@ def test_probe_bwrap_userns_respects_sysctl(
 
     def fail_run_cmd(*_args: object, **_kwargs: object) -> int:
         pytest.fail("bubblewrap should not be probed when sysctl=0")
+        raise AssertionError("unreachable")
 
     monkeypatch.setattr(backends, "run_cmd", fail_run_cmd)
 
@@ -157,26 +175,37 @@ def test_probe_bwrap_userns_respects_sysctl(
         )
 
 
-def test_prepare_bwrap_logs_unavailability(
+def test_backend_run_logs_bubblewrap_unavailability(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``_prepare_bwrap`` propagates friendly logging on hard failure."""
+    """``Backend.run`` logs and skips when bubblewrap becomes unavailable."""
     messages: list[str] = []
 
-    def fake_probe(*_args: object, **_kwargs: object) -> list[str]:
+    def fake_prepare(
+        *_args: object, **_kwargs: object
+    ) -> list[str] | None:  # pragma: no cover - replaced in test
         message = "bubblewrap unavailable"
         raise backends.BubblewrapUnavailable(message)
 
-    monkeypatch.setattr(backends, "_probe_bwrap_userns", fake_probe)
-
-    result = backends._prepare_bwrap(
-        typ.cast("BaseCommand", _StubCommand()),
-        tmp_path,
-        "echo hi",
-        messages.append,
-        timeout=None,
-        container_tmp=tmp_path / "tmpfs",
+    backend = backends.Backend(
+        name="bubblewrap",
+        binary="bwrap",
+        prepare=fake_prepare,  # type: ignore[arg-type]
     )
 
-    assert result is None
+    def fake_get_command(binary: str) -> _StubCommand:
+        assert binary == "bwrap"
+        return _StubCommand()
+
+    monkeypatch.setattr(backends, "get_command", fake_get_command)
+
+    outcome = backend.run(
+        tmp_path,
+        "echo hi",
+        timeout=None,
+        logger=messages.append,
+        container_tmp=tmp_path,
+    )
+
+    assert outcome is None
     assert messages == ["bubblewrap unavailable"]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -162,7 +162,7 @@ def test_probe_bwrap_userns_respects_sysctl(
     monkeypatch.setattr(backends, "_UNPRIVILEGED_USERNS_PATH", flag)
     monkeypatch.setattr(backends, "_is_privileged_user", lambda: False)
 
-    def fail_run_cmd(*_args: object, **_kwargs: object) -> int:
+    def fail_run_cmd(*_args: object, **_kwargs: object) -> typ.NoReturn:
         pytest.fail("bubblewrap should not be probed when sysctl=0")
         raise AssertionError("unreachable")
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import typing as typ
 
+import pytest
+from plumbum.commands.processes import ProcessExecutionError
+
 from polythene import backends
 
 if typ.TYPE_CHECKING:
     import pathlib
 
-    import pytest
     from plumbum.commands.base import BaseCommand
 else:  # pragma: no cover - runtime sentinel for typing-only import
     BaseCommand = typ.Any  # type: ignore[assignment]
@@ -101,7 +103,7 @@ def test_proot_backend_run_uses_non_login_shell(
     monkeypatch.setattr(backends, "get_command", fake_get_command)
     monkeypatch.setattr(backends, "run_cmd", fake_run_cmd)
 
-    rc = backend.run(
+    outcome = backend.run(
         tmp_path,
         "echo hi",
         timeout=None,
@@ -109,10 +111,72 @@ def test_proot_backend_run_uses_non_login_shell(
         container_tmp=tmp_path,
     )
 
-    assert rc == 0
+    assert outcome == (backend.name, 0)
     assert len(stub.calls) == 2
     probe_call, exec_call = stub.calls
     assert probe_call[-2:] == ("-c", "true")
     assert exec_call[-2] == "-c"
     assert exec_call[-1] == "echo hi"
     assert executed == stub.calls
+
+
+def test_probe_bwrap_userns_permission_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Permission denied during probing should disable bubblewrap early."""
+
+    def fake_run_cmd(_cmd: tuple[str, ...], *, fg: bool, timeout: int | None) -> int:
+        raise ProcessExecutionError(_cmd, 1, "", "Permission denied")
+
+    monkeypatch.setattr(backends, "run_cmd", fake_run_cmd)
+
+    with pytest.raises(backends.BubblewrapUnavailable, match="unprivileged"):
+        backends._probe_bwrap_userns(
+            typ.cast("BaseCommand", _StubCommand()),
+            timeout=None,
+            logger=lambda _msg: None,
+        )
+
+
+def test_probe_bwrap_userns_respects_sysctl(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The userns sysctl check short-circuits bubblewrap probing."""
+    flag = tmp_path / "unprivileged_userns_clone"
+    flag.write_text("0", encoding="utf-8")
+    monkeypatch.setattr(backends, "_UNPRIVILEGED_USERNS_PATH", flag)
+
+    def fail_run_cmd(*_args: object, **_kwargs: object) -> int:
+        pytest.fail("bubblewrap should not be probed when sysctl=0")
+
+    monkeypatch.setattr(backends, "run_cmd", fail_run_cmd)
+
+    with pytest.raises(backends.BubblewrapUnavailable, match="requires unprivileged"):
+        backends._probe_bwrap_userns(
+            typ.cast("BaseCommand", _StubCommand()),
+            timeout=None,
+            logger=lambda _msg: None,
+        )
+
+
+def test_prepare_bwrap_logs_unavailability(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_prepare_bwrap`` propagates friendly logging on hard failure."""
+    messages: list[str] = []
+
+    def fake_probe(*_args: object, **_kwargs: object) -> list[str]:
+        message = "bubblewrap unavailable"
+        raise backends.BubblewrapUnavailable(message)
+
+    monkeypatch.setattr(backends, "_probe_bwrap_userns", fake_probe)
+
+    result = backends._prepare_bwrap(
+        typ.cast("BaseCommand", _StubCommand()),
+        tmp_path,
+        "echo hi",
+        messages.append,
+        timeout=None,
+        container_tmp=tmp_path / "tmpfs",
+    )
+
+    assert result is None
+    assert messages == ["bubblewrap unavailable"]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -164,7 +164,7 @@ def test_probe_bwrap_userns_respects_sysctl(
 
     def fail_run_cmd(*_args: object, **_kwargs: object) -> typ.NoReturn:
         pytest.fail("bubblewrap should not be probed when sysctl=0")
-        raise AssertionError("unreachable")
+        raise AssertionError("unreachable")  # Keep Pyright happy
 
     monkeypatch.setattr(backends, "run_cmd", fail_run_cmd)
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -162,8 +162,9 @@ def test_probe_bwrap_userns_respects_sysctl(
     monkeypatch.setattr(backends, "_UNPRIVILEGED_USERNS_PATH", flag)
     monkeypatch.setattr(backends, "_is_privileged_user", lambda: False)
 
-    def fail_run_cmd(*_args: object, **_kwargs: object) -> None:
+    def fail_run_cmd(*_args: object, **_kwargs: object) -> typ.NoReturn:
         pytest.fail("bubblewrap should not be probed when sysctl=0")
+        raise AssertionError("unreachable")  # appease Pyright's flow analysis
 
     monkeypatch.setattr(backends, "run_cmd", fail_run_cmd)
 

--- a/tests/test_polythene.py
+++ b/tests/test_polythene.py
@@ -106,9 +106,7 @@ class _DummyBackend:
         container_tmp: Path,
     ) -> tuple[str, int] | None:
         self.calls.append((root, inner_cmd, timeout))
-        if self.exit_code is None:
-            return None
-        return (self.name, self.exit_code)
+        return None if self.exit_code is None else (self.name, self.exit_code)
 
 
 def test_normalise_command_args_flattens_single_sequence() -> None:

--- a/tests/test_polythene.py
+++ b/tests/test_polythene.py
@@ -218,6 +218,10 @@ def test_cmd_exec_logs_bubblewrap_fallback(
     )
 
     assert result.exit_code == 0
+    assert (
+        "Warning: backend.run returned None for backend 'bubblewrap'."
+        " This may indicate an error or an unsupported condition."
+    ) in result.stderr
     assert "bubblewrap unavailable: falling back to proot" in result.stderr
     assert bubblewrap.calls == [(root, "true", None)]
     assert proot.calls == [(root, "true", None)]

--- a/tests/test_polythene.py
+++ b/tests/test_polythene.py
@@ -86,12 +86,12 @@ def test_cmd_pull_retries_existing_uuid(
 class _DummyBackend:
     def __init__(
         self,
-        return_code: int | None,
+        exit_code: int | None,
         *,
         requires_root: bool = False,
         name: str = "dummy",
     ) -> None:
-        self.return_code = return_code
+        self.exit_code = exit_code
         self.requires_root = requires_root
         self.name = name
         self.calls: list[tuple[Path, str, int | None]] = []
@@ -104,9 +104,11 @@ class _DummyBackend:
         timeout: int | None,
         logger: typ.Callable[[str], None],
         container_tmp: Path,
-    ) -> int | None:
+    ) -> tuple[str, int] | None:
         self.calls.append((root, inner_cmd, timeout))
-        return self.return_code
+        if self.exit_code is None:
+            return None
+        return (self.name, self.exit_code)
 
 
 def test_normalise_command_args_flattens_single_sequence() -> None:
@@ -187,6 +189,40 @@ def test_cmd_exec_uses_first_available_backend(
     assert result.exit_code == 0
     assert primary.calls == [(root, "echo 'hello world'", 15)]
     assert fallback.calls == []
+
+
+def test_cmd_exec_logs_bubblewrap_fallback(
+    run_cli: typ.Callable[[typ.Sequence[str]], CliResult],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When bubblewrap is unavailable the CLI logs a friendly fallback."""
+    root = tmp_path / "uuid-bwrap"
+    root.mkdir(parents=True)
+
+    bubblewrap = _DummyBackend(None, name="bubblewrap")
+    proot = _DummyBackend(0, name="proot")
+    monkeypatch.setattr(isolation, "BACKENDS", (bubblewrap, proot))
+    monkeypatch.setattr(isolation, "IS_ROOT", True)
+    monkeypatch.setattr(isolation, "VERBOSE", True)
+
+    result = run_cli(
+        [
+            "exec",
+            "uuid-bwrap",
+            "--store",
+            tmp_path.as_posix(),
+            "--isolation",
+            "bubblewrap",
+            "--",
+            "true",
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert "bubblewrap unavailable: falling back to proot" in result.stderr
+    assert bubblewrap.calls == [(root, "true", None)]
+    assert proot.calls == [(root, "true", None)]
 
 
 def test_cmd_exec_allows_leading_hyphen_arguments(

--- a/tests/test_polythene.py
+++ b/tests/test_polythene.py
@@ -218,10 +218,6 @@ def test_cmd_exec_logs_bubblewrap_fallback(
     )
 
     assert result.exit_code == 0
-    assert (
-        "Warning: backend.run returned None for backend 'bubblewrap'."
-        " This may indicate an error or an unsupported condition."
-    ) in result.stderr
     assert "bubblewrap unavailable: falling back to proot" in result.stderr
     assert bubblewrap.calls == [(root, "true", None)]
     assert proot.calls == [(root, "true", None)]


### PR DESCRIPTION
## Summary
- teach the bubblewrap backend to detect disabled user namespaces and bail out cleanly
- log isolation fallback transitions so `polythene exec` explains when it switches runners
- extend backend and CLI tests to cover the new detection and fallback behaviour

## Testing
- make check-fmt
- make typecheck
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68eedb82798c83228f8b33ce493295db

## Summary by Sourcery

Detect when bubblewrap cannot use unprivileged user namespaces and gracefully fall back to alternate isolation (proot) with clear logging of the transition

New Features:
- Introduce BubblewrapUnavailable exception and detect disabled user namespaces via sysctl or permission errors
- Extend backend.run to return the chosen backend name alongside its exit code
- Log isolation backend fallback transitions during CLI exec commands

Enhancements:
- Refactor _prepare_bwrap to catch unavailability and signal fallback
- Refactor isolation.cmd_exec to iterate through backends, skip unavailable ones, and record current isolation

Tests:
- Add tests for permission-denied and sysctl-based bubblewrap probing failures
- Add tests verifying prepare_bwrap logging and CLI exec fallback behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Detect when unprivileged user-namespace isolation is unavailable and automatically fall back to an alternative isolation backend.
  - Execution logs now indicate which isolation backend is active and when a fallback occurs.

- **Bug Fixes**
  - Graceful handling of permission-denied and related probe failures to avoid crashes and ensure reliable fallback.
  - Backend outcomes standardized to include the active backend name with its exit code; unprobed backends return None.

- **Tests**
  - Added tests covering probe failures, sysctl gating, fallback logging, and end-to-end fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->