### PR TITLE
Enforce ruff complexity and argument limits

### DIFF
--- a/polythene/backends.py
+++ b/polythene/backends.py
@@ -16,6 +16,7 @@ from .script_utils import ensure_directory, get_command
 
 __all__ = [
     "Backend",
+    "BackendContext",
     "BubblewrapUnavailable",
     "create_backends",
     "ensure_runtime_paths",
@@ -24,9 +25,17 @@ __all__ = [
 
 Logger = typ.Callable[[str], None]
 
-PrepareFn = typ.Callable[
-    [BaseCommand, Path, str, Logger, int | None, Path], list[str] | None
-]
+
+@dc.dataclass(slots=True, frozen=True)
+class BackendContext:
+    """Configuration shared between backend probes and execution."""
+
+    logger: Logger
+    timeout: int | None
+    container_tmp: Path
+
+
+PrepareFn = typ.Callable[[BaseCommand, Path, str, BackendContext], list[str] | None]
 
 
 class BubblewrapUnavailable(RuntimeError):  # noqa: N818 - aligns with CLI wording
@@ -84,11 +93,11 @@ class Backend:
         root: Path,
         inner_cmd: str,
         *,
-        timeout: int | None,
-        logger: Logger,
-        container_tmp: Path,
+        context: BackendContext,
     ) -> tuple[str, int] | None:
         """Probe and run the backend, returning the chosen name and exit status."""
+        logger = context.logger
+        timeout = context.timeout
         try:
             tool = get_command(self.binary)
         except SystemExit as exc:
@@ -99,7 +108,7 @@ class Backend:
             ensure_runtime_paths(root)
 
         try:
-            args = self.prepare(tool, root, inner_cmd, logger, timeout, container_tmp)
+            args = self.prepare(tool, root, inner_cmd, context)
         except BubblewrapUnavailable as exc:
             logger(str(exc))
             return None
@@ -120,12 +129,9 @@ def ensure_runtime_paths(root: Path) -> None:
         ensure_directory(root / sub)
 
 
-def _probe_bwrap_userns(
-    bwrap: BaseCommand,
-    *,
-    timeout: int | None,
-    logger: Logger,
-) -> list[str]:
+def _probe_bwrap_userns(bwrap: BaseCommand, context: BackendContext) -> list[str]:
+    logger = context.logger
+    timeout = context.timeout
     if not _is_privileged_user():
         try:
             value = _UNPRIVILEGED_USERNS_PATH.read_text(encoding="utf-8").strip()
@@ -168,9 +174,9 @@ def _probe_bwrap_proc(
     bwrap: BaseCommand,
     base_flags: list[str],
     root: Path,
-    *,
-    timeout: int | None,
+    context: BackendContext,
 ) -> list[str]:
+    timeout = context.timeout
     probe = [
         *base_flags,
         "--bind",
@@ -191,13 +197,13 @@ def _prepare_bwrap(
     bwrap: BaseCommand,
     root: Path,
     inner_cmd: str,
-    logger: Logger,
-    timeout: int | None,
-    container_tmp: Path,
+    context: BackendContext,
 ) -> list[str] | None:
-    base_flags = _probe_bwrap_userns(bwrap, timeout=timeout, logger=logger)
+    timeout = context.timeout
+    container_tmp = context.container_tmp
+    base_flags = _probe_bwrap_userns(bwrap, context)
     base_flags.extend(["--unshare-pid", "--unshare-ipc", "--unshare-uts"])
-    proc_flags = _probe_bwrap_proc(bwrap, base_flags, root, timeout=timeout)
+    proc_flags = _probe_bwrap_proc(bwrap, base_flags, root, context)
     probe_args = [
         *base_flags,
         "--bind",
@@ -243,10 +249,9 @@ def _prepare_proot(
     proot: BaseCommand,
     root: Path,
     inner_cmd: str,
-    _logger: Logger,
-    timeout: int | None,
-    _container_tmp: Path,
+    context: BackendContext,
 ) -> list[str] | None:
+    timeout = context.timeout
     probe_args = ["-R", str(root), "-0", "/bin/sh", "-c", "true"]
     try:
         run_cmd(proot[tuple(probe_args)], fg=True, timeout=timeout)
@@ -259,10 +264,9 @@ def _prepare_chroot(
     chroot: BaseCommand,
     root: Path,
     inner_cmd: str,
-    _logger: Logger,
-    timeout: int | None,
-    _container_tmp: Path,
+    context: BackendContext,
 ) -> list[str] | None:
+    timeout = context.timeout
     probe_args = [str(root), "/bin/sh", "-c", "true"]
     try:
         run_cmd(chroot[tuple(probe_args)], fg=True, timeout=timeout)

--- a/polythene/backends.py
+++ b/polythene/backends.py
@@ -35,7 +35,8 @@ class BackendContext:
     container_tmp: Path
 
 
-PrepareFn = typ.Callable[[BaseCommand, Path, str, BackendContext], list[str] | None]
+PrepareFn = typ.Callable[[BaseCommand, Path, str], list[str] | None]
+PrepareFactory = typ.Callable[[BackendContext], PrepareFn]
 
 
 class BubblewrapUnavailable(RuntimeError):  # noqa: N818 - aligns with CLI wording
@@ -84,7 +85,7 @@ class Backend:
 
     name: str
     binary: str
-    prepare: PrepareFn
+    prepare_factory: PrepareFactory
     ensure_dirs: bool = True
     requires_root: bool = False
 
@@ -108,7 +109,8 @@ class Backend:
             ensure_runtime_paths(root)
 
         try:
-            args = self.prepare(tool, root, inner_cmd, context)
+            prepare = self.prepare_factory(context)
+            args = prepare(tool, root, inner_cmd)
         except BubblewrapUnavailable as exc:
             logger(str(exc))
             return None
@@ -174,9 +176,9 @@ def _probe_bwrap_proc(
     bwrap: BaseCommand,
     base_flags: list[str],
     root: Path,
-    context: BackendContext,
+    *,
+    timeout: int | None,
 ) -> list[str]:
-    timeout = context.timeout
     probe = [
         *base_flags,
         "--bind",
@@ -193,91 +195,105 @@ def _probe_bwrap_proc(
     return ["--proc", "/proc"]
 
 
-def _prepare_bwrap(
-    bwrap: BaseCommand,
-    root: Path,
-    inner_cmd: str,
-    context: BackendContext,
-) -> list[str] | None:
+def make_prepare_bwrap(context: BackendContext) -> PrepareFn:
     timeout = context.timeout
     container_tmp = context.container_tmp
-    base_flags = _probe_bwrap_userns(bwrap, context)
-    base_flags.extend(["--unshare-pid", "--unshare-ipc", "--unshare-uts"])
-    proc_flags = _probe_bwrap_proc(bwrap, base_flags, root, context)
-    probe_args = [
-        *base_flags,
-        "--bind",
-        str(root),
-        "/",
-        "--dev-bind",
-        "/dev",
-        "/dev",
-        *proc_flags,
-        "--tmpfs",
-        str(container_tmp),
-        "--chdir",
-        "/",
-        "/bin/sh",
-        "-c",
-        "true",
-    ]
-    try:
-        run_cmd(bwrap[tuple(probe_args)], fg=True, timeout=timeout)
-    except (ProcessExecutionError, SystemExit, OSError):
-        return None
 
-    return [
-        *base_flags,
-        "--bind",
-        str(root),
-        "/",
-        "--dev-bind",
-        "/dev",
-        "/dev",
-        *proc_flags,
-        "--tmpfs",
-        str(container_tmp),
-        "--chdir",
-        "/",
-        "/bin/sh",
-        "-c",
-        inner_cmd,
-    ]
+    def _prepare_bwrap(
+        bwrap: BaseCommand,
+        root: Path,
+        inner_cmd: str,
+    ) -> list[str] | None:
+        base_flags = _probe_bwrap_userns(bwrap, context)
+        base_flags.extend(["--unshare-pid", "--unshare-ipc", "--unshare-uts"])
+        proc_flags = _probe_bwrap_proc(
+            bwrap,
+            base_flags,
+            root,
+            timeout=timeout,
+        )
+        probe_args = [
+            *base_flags,
+            "--bind",
+            str(root),
+            "/",
+            "--dev-bind",
+            "/dev",
+            "/dev",
+            *proc_flags,
+            "--tmpfs",
+            str(container_tmp),
+            "--chdir",
+            "/",
+            "/bin/sh",
+            "-c",
+            "true",
+        ]
+        try:
+            run_cmd(bwrap[tuple(probe_args)], fg=True, timeout=timeout)
+        except (ProcessExecutionError, SystemExit, OSError):
+            return None
+
+        return [
+            *base_flags,
+            "--bind",
+            str(root),
+            "/",
+            "--dev-bind",
+            "/dev",
+            "/dev",
+            *proc_flags,
+            "--tmpfs",
+            str(container_tmp),
+            "--chdir",
+            "/",
+            "/bin/sh",
+            "-c",
+            inner_cmd,
+        ]
+
+    return _prepare_bwrap
 
 
-def _prepare_proot(
-    proot: BaseCommand,
-    root: Path,
-    inner_cmd: str,
-    context: BackendContext,
-) -> list[str] | None:
+def make_prepare_proot(context: BackendContext) -> PrepareFn:
     timeout = context.timeout
-    probe_args = ["-R", str(root), "-0", "/bin/sh", "-c", "true"]
-    try:
-        run_cmd(proot[tuple(probe_args)], fg=True, timeout=timeout)
-    except (ProcessExecutionError, SystemExit, OSError):
-        return None
-    return ["-R", str(root), "-0", "/bin/sh", "-c", inner_cmd]
+
+    def _prepare_proot(
+        proot: BaseCommand,
+        root: Path,
+        inner_cmd: str,
+    ) -> list[str] | None:
+        probe_args = ["-R", str(root), "-0", "/bin/sh", "-c", "true"]
+        try:
+            run_cmd(proot[tuple(probe_args)], fg=True, timeout=timeout)
+        except (ProcessExecutionError, SystemExit, OSError):
+            return None
+        return ["-R", str(root), "-0", "/bin/sh", "-c", inner_cmd]
+
+    return _prepare_proot
 
 
-def _prepare_chroot(
-    chroot: BaseCommand,
-    root: Path,
-    inner_cmd: str,
-    context: BackendContext,
-) -> list[str] | None:
+def make_prepare_chroot(context: BackendContext) -> PrepareFn:
     timeout = context.timeout
-    probe_args = [str(root), "/bin/sh", "-c", "true"]
-    try:
-        run_cmd(chroot[tuple(probe_args)], fg=True, timeout=timeout)
-    except (ProcessExecutionError, SystemExit, OSError):
-        return None
-    return [
-        str(root),
-        "/bin/sh",
-        "-lc",
-        f"export PATH=/bin:/sbin:/usr/bin:/usr/sbin; {inner_cmd}",
-    ]
+
+    def _prepare_chroot(
+        chroot: BaseCommand,
+        root: Path,
+        inner_cmd: str,
+    ) -> list[str] | None:
+        probe_args = [str(root), "/bin/sh", "-c", "true"]
+        try:
+            run_cmd(chroot[tuple(probe_args)], fg=True, timeout=timeout)
+        except (ProcessExecutionError, SystemExit, OSError):
+            return None
+        return [
+            str(root),
+            "/bin/sh",
+            "-lc",
+            f"export PATH=/bin:/sbin:/usr/bin:/usr/sbin; {inner_cmd}",
+        ]
+
+    return _prepare_chroot
 
 
 def create_backends() -> tuple[Backend, ...]:
@@ -286,17 +302,17 @@ def create_backends() -> tuple[Backend, ...]:
         Backend(
             name="bubblewrap",
             binary="bwrap",
-            prepare=_prepare_bwrap,
+            prepare_factory=make_prepare_bwrap,
         ),
         Backend(
             name="proot",
             binary="proot",
-            prepare=_prepare_proot,
+            prepare_factory=make_prepare_proot,
         ),
         Backend(
             name="chroot",
             binary="chroot",
-            prepare=_prepare_chroot,
+            prepare_factory=make_prepare_chroot,
             ensure_dirs=False,
             requires_root=True,
         ),

--- a/polythene/isolation.py
+++ b/polythene/isolation.py
@@ -17,7 +17,7 @@ from cyclopts import App, Parameter
 from plumbum.commands.processes import ProcessExecutionError
 from uuid6 import uuid7
 
-from .backends import Backend, create_backends, ensure_runtime_paths
+from .backends import Backend, BackendContext, create_backends, ensure_runtime_paths
 from .script_utils import ensure_directory, get_command, run_cmd
 
 # -------------------- Configuration --------------------
@@ -266,6 +266,12 @@ def cmd_exec(
 
     current_isolation = isolation
 
+    context = BackendContext(
+        logger=log,
+        timeout=timeout,
+        container_tmp=CONTAINER_TMP,
+    )
+
     for index, backend in enumerate(selected_backends):
         if backend.requires_root and not IS_ROOT:
             continue
@@ -273,9 +279,7 @@ def cmd_exec(
             outcome = backend.run(
                 root,
                 inner_cmd,
-                timeout=timeout,
-                logger=log,
-                container_tmp=CONTAINER_TMP,
+                context=context,
             )
         except ProcessExecutionError as exc:
             raise SystemExit(_normalise_retcode(exc.retcode)) from exc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,14 @@ select = [
     "D",
     "ANN",
 ]
-per-file-ignores = {"**/test_*.py" = ["S101"]}
+extend-select = ["PLR0913"]
+per-file-ignores = {"**/test_*.py" = ["S101", "PLR0913"]}
+
+[tool.ruff.lint.mccabe]
+max-complexity = 9
+
+[tool.ruff.lint.pylint]
+max-args = 4
 
 [tool.ruff.lint.flake8-import-conventions]
 # Declare the banned `from` imports.

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -12,8 +12,6 @@ from plumbum.commands.processes import ProcessExecutionError
 from polythene import backends
 
 if typ.TYPE_CHECKING:
-    import pathlib
-
     from plumbum.commands.base import BaseCommand
 else:  # pragma: no cover - runtime sentinel for typing-only import
     BaseCommand = typ.Any  # type: ignore[assignment]
@@ -37,6 +35,7 @@ def _make_context(
     timeout: int | None = None,
 ) -> backends.BackendContext:
     """Return a backend context tailored for the current test."""
+    container_tmp = pathlib.Path(container_tmp)
     return backends.BackendContext(
         logger=logger,
         timeout=timeout,

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import errno
+import pathlib
 import typing as typ
 
 import pytest
@@ -29,6 +30,20 @@ class _StubCommand:
         return args
 
 
+def _make_context(
+    *,
+    container_tmp: pathlib.Path,
+    logger: typ.Callable[[str], None] = lambda _msg: None,
+    timeout: int | None = None,
+) -> backends.BackendContext:
+    """Return a backend context tailored for the current test."""
+    return backends.BackendContext(
+        logger=logger,
+        timeout=timeout,
+        container_tmp=container_tmp,
+    )
+
+
 def test_prepare_proot_avoids_login_shell(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -48,13 +63,13 @@ def test_prepare_proot_avoids_login_shell(
     monkeypatch.setattr(backends, "run_cmd", fake_run_cmd)
 
     inner_cmd = "test -x /usr/bin/rust-toy-app"
+    context = _make_context(container_tmp=tmp_path, logger=lambda _msg: None)
+
     result = backends._prepare_proot(
         typ.cast("BaseCommand", stub),
         tmp_path,
         inner_cmd,
-        lambda _msg: None,
-        timeout=None,
-        _container_tmp=tmp_path,
+        context,
     )
 
     assert stub.calls[0] == (
@@ -104,12 +119,12 @@ def test_proot_backend_run_uses_non_login_shell(
     monkeypatch.setattr(backends, "get_command", fake_get_command)
     monkeypatch.setattr(backends, "run_cmd", fake_run_cmd)
 
+    context = _make_context(container_tmp=tmp_path, logger=lambda _msg: None)
+
     outcome = backend.run(
         tmp_path,
         "echo hi",
-        timeout=None,
-        logger=lambda _msg: None,
-        container_tmp=tmp_path,
+        context=context,
     )
 
     assert outcome == (backend.name, 0)
@@ -121,7 +136,9 @@ def test_proot_backend_run_uses_non_login_shell(
     assert executed == stub.calls
 
 
-def test_probe_bwrap_userns_permission_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_probe_bwrap_userns_permission_denied(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Permission denied during probing should disable bubblewrap early."""
 
     def fake_run_cmd(_cmd: tuple[str, ...], *, fg: bool, timeout: int | None) -> int:
@@ -132,12 +149,13 @@ def test_probe_bwrap_userns_permission_denied(monkeypatch: pytest.MonkeyPatch) -
     with pytest.raises(backends.BubblewrapUnavailable, match="unprivileged"):
         backends._probe_bwrap_userns(
             typ.cast("BaseCommand", _StubCommand()),
-            timeout=None,
-            logger=lambda _msg: None,
+            _make_context(container_tmp=tmp_path, logger=lambda _msg: None),
         )
 
 
-def test_probe_bwrap_userns_oserror_eperm(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_probe_bwrap_userns_oserror_eperm(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """OS errors reporting ``EPERM`` disable bubblewrap immediately."""
 
     def fake_run_cmd(_cmd: tuple[str, ...], *, fg: bool, timeout: int | None) -> int:
@@ -148,8 +166,7 @@ def test_probe_bwrap_userns_oserror_eperm(monkeypatch: pytest.MonkeyPatch) -> No
     with pytest.raises(backends.BubblewrapUnavailable, match="unprivileged"):
         backends._probe_bwrap_userns(
             typ.cast("BaseCommand", _StubCommand()),
-            timeout=None,
-            logger=lambda _msg: None,
+            _make_context(container_tmp=tmp_path, logger=lambda _msg: None),
         )
 
 
@@ -171,8 +188,7 @@ def test_probe_bwrap_userns_respects_sysctl(
     with pytest.raises(backends.BubblewrapUnavailable, match="requires unprivileged"):
         backends._probe_bwrap_userns(
             typ.cast("BaseCommand", _StubCommand()),
-            timeout=None,
-            logger=lambda _msg: None,
+            _make_context(container_tmp=tmp_path, logger=lambda _msg: None),
         )
 
 
@@ -195,8 +211,7 @@ def test_probe_bwrap_userns_sysctl_missing(
 
     result = backends._probe_bwrap_userns(
         typ.cast("BaseCommand", stub),
-        timeout=None,
-        logger=lambda _msg: None,
+        _make_context(container_tmp=tmp_path, logger=lambda _msg: None),
     )
 
     assert result == ["--unshare-user", "--uid", "0", "--gid", "0"]
@@ -224,8 +239,7 @@ def test_probe_bwrap_userns_sysctl_read_error(
 
     result = backends._probe_bwrap_userns(
         typ.cast("BaseCommand", stub),
-        timeout=None,
-        logger=logs.append,
+        _make_context(container_tmp=tmp_path, logger=logs.append),
     )
 
     assert result == ["--unshare-user", "--uid", "0", "--gid", "0"]
@@ -258,8 +272,7 @@ def test_probe_bwrap_userns_skips_sysctl_for_privileged(
 
     result = backends._probe_bwrap_userns(
         typ.cast("BaseCommand", stub),
-        timeout=None,
-        logger=lambda _msg: None,
+        _make_context(container_tmp=tmp_path, logger=lambda _msg: None),
     )
 
     assert result == ["--unshare-user", "--uid", "0", "--gid", "0"]
@@ -290,12 +303,12 @@ def test_backend_run_logs_bubblewrap_unavailability(
 
     monkeypatch.setattr(backends, "get_command", fake_get_command)
 
+    context = _make_context(container_tmp=tmp_path, logger=messages.append)
+
     outcome = backend.run(
         tmp_path,
         "echo hi",
-        timeout=None,
-        logger=messages.append,
-        container_tmp=tmp_path,
+        context=context,
     )
 
     assert outcome is None

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -47,7 +47,7 @@ def _make_context(
 def test_prepare_proot_avoids_login_shell(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``_prepare_proot`` should not request a login shell.
+    """``make_prepare_proot`` should not request a login shell.
 
     Login shells source profile scripts, which can mutate environment state in
     unexpected ways.  The probe command already uses ``-c`` so the execution
@@ -65,11 +65,11 @@ def test_prepare_proot_avoids_login_shell(
     inner_cmd = "test -x /usr/bin/rust-toy-app"
     context = _make_context(container_tmp=tmp_path, logger=lambda _msg: None)
 
-    result = backends._prepare_proot(
+    prepare = backends.make_prepare_proot(context)
+    result = prepare(
         typ.cast("BaseCommand", stub),
         tmp_path,
         inner_cmd,
-        context,
     )
 
     assert stub.calls[0] == (
@@ -98,6 +98,51 @@ def test_prepare_proot_avoids_login_shell(
         "-c",
         inner_cmd,
     ]
+
+
+def test_make_prepare_bwrap_binds_context(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``make_prepare_bwrap`` captures timeout and tmp paths from context."""
+    base_flags = ["--unshare-user"]
+    proc_flags = ["--proc", "/proc"]
+    context = _make_context(
+        container_tmp=tmp_path / "container-tmp",
+        timeout=37,
+        logger=lambda _msg: None,
+    )
+    probe_calls: list[tuple[tuple[str, ...], int | None]] = []
+
+    monkeypatch.setattr(
+        backends, "_probe_bwrap_userns", lambda *_args: base_flags.copy()
+    )
+    monkeypatch.setattr(
+        backends,
+        "_probe_bwrap_proc",
+        lambda *_args, **_kwargs: proc_flags.copy(),
+    )
+
+    def fake_run_cmd(
+        cmd: tuple[str, ...], *, fg: bool, timeout: int | None
+    ) -> int:  # pragma: no cover - instrumented below
+        assert fg is True
+        probe_calls.append((cmd, timeout))
+        return 0
+
+    monkeypatch.setattr(backends, "run_cmd", fake_run_cmd)
+
+    prepare = backends.make_prepare_bwrap(context)
+    stub = _StubCommand()
+
+    result = prepare(typ.cast("BaseCommand", stub), tmp_path, "echo hi")
+
+    assert len(stub.calls) == 1
+    probe_cmd, timeout = probe_calls[0]
+    assert timeout == 37
+    assert "--tmpfs" in probe_cmd
+    idx = probe_cmd.index("--tmpfs")
+    assert probe_cmd[idx + 1] == str(context.container_tmp)
+    assert result[-2:] == ["-c", "echo hi"]
 
 
 def test_proot_backend_run_uses_non_login_shell(
@@ -134,6 +179,34 @@ def test_proot_backend_run_uses_non_login_shell(
     assert exec_call[-2] == "-c"
     assert exec_call[-1] == "echo hi"
     assert executed == stub.calls
+
+
+def test_probe_bwrap_userns_uses_context_timeout(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_probe_bwrap_userns`` passes the context timeout to ``run_cmd``."""
+    stub = _StubCommand()
+    timeouts: list[int | None] = []
+
+    def fake_run_cmd(cmd: tuple[str, ...], *, fg: bool, timeout: int | None) -> int:
+        assert cmd[-1] == "true"
+        timeouts.append(timeout)
+        return 0
+
+    monkeypatch.setattr(backends, "run_cmd", fake_run_cmd)
+    monkeypatch.setattr(backends, "_is_privileged_user", lambda: True)
+
+    context = _make_context(
+        container_tmp=tmp_path, logger=lambda _msg: None, timeout=99
+    )
+
+    result = backends._probe_bwrap_userns(
+        typ.cast("BaseCommand", stub),
+        context,
+    )
+
+    assert result == ["--unshare-user", "--uid", "0", "--gid", "0"]
+    assert timeouts == [99]
 
 
 def test_probe_bwrap_userns_permission_denied(
@@ -286,7 +359,9 @@ def test_backend_run_logs_bubblewrap_unavailability(
     messages: list[str] = []
 
     def fake_prepare(
-        *_args: object, **_kwargs: object
+        _tool: object,
+        _root: object,
+        _inner_cmd: object,
     ) -> list[str] | None:  # pragma: no cover - replaced in test
         message = "bubblewrap unavailable"
         raise backends.BubblewrapUnavailable(message)
@@ -294,7 +369,7 @@ def test_backend_run_logs_bubblewrap_unavailability(
     backend = backends.Backend(
         name="bubblewrap",
         binary="bwrap",
-        prepare=fake_prepare,  # type: ignore[arg-type]
+        prepare_factory=lambda _context: fake_prepare,
     )
 
     def fake_get_command(binary: str) -> _StubCommand:

--- a/tests/test_polythene.py
+++ b/tests/test_polythene.py
@@ -9,6 +9,7 @@ import pytest
 
 import polythene
 import polythene.isolation as isolation
+from polythene import backends
 
 if typ.TYPE_CHECKING:
     from pathlib import Path
@@ -101,11 +102,9 @@ class _DummyBackend:
         root: Path,
         inner_cmd: str,
         *,
-        timeout: int | None,
-        logger: typ.Callable[[str], None],
-        container_tmp: Path,
+        context: backends.BackendContext,
     ) -> tuple[str, int] | None:
-        self.calls.append((root, inner_cmd, timeout))
+        self.calls.append((root, inner_cmd, context.timeout))
         return None if self.exit_code is None else (self.name, self.exit_code)
 
 


### PR DESCRIPTION
## Summary
- enforce a Ruff C90 complexity ceiling of 9 and limit function arguments to four with test exclusions
- introduce a backend execution context so backends satisfy the tighter argument budget and update isolation code and tests

## Testing
- make check-fmt
- make typecheck
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_6906193e360483228758b028df0654ea

## Summary by Sourcery

Introduce a BackendContext dataclass to streamline passing of logger, timeout, and temporary paths to backend functions, refactor backend and isolation code accordingly, and enforce stricter Ruff and Pylint rules for complexity and argument count with appropriate test exemptions.

Enhancements:
- Introduce BackendContext to encapsulate shared backend parameters and refactor prepare/probe/run functions to use it
- Refactor isolation logic to construct and pass BackendContext to backend executions

Build:
- Configure Ruff to enforce a maximum cyclomatic complexity of 9 and Pylint to limit function arguments to 4
- Add per-file ignores for tests to exempt complexity and argument limit checks

Tests:
- Add a test helper to create BackendContext and update backend tests to use the new context parameter
- Adjust polythene isolation tests to pass BackendContext instead of individual parameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated backend preparation and execution to use a single context object for logger, timeout, and temp paths, simplifying parameter flow and improving consistency.

* **Tests**
  * Updated tests to construct and pass the new context object, and to verify behavior under the context-driven flow.

* **Chores**
  * Tightened linting and complexity rules in project configuration for improved code quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->