### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,24 @@
+name: Mutation testing
+
+# Thin caller of the shared mutation-testing reusable workflow; caller
+# guide: leynos/shared-actions docs/mutation-mutmut-workflow.md.
+on:
+  schedule:
+    - cron: "50 5 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    with:
+      paths: "polythene/"
+      module-prefix-strip: ""

--- a/polythene/backends.py
+++ b/polythene/backends.py
@@ -121,7 +121,9 @@ class Backend:
 
         logger(f"Executing via {self.name}")
         result = run_cmd(tool[tuple(args)], fg=True, timeout=timeout)
-        exit_code = int(result) if result is not None else 0
+        exit_code = (
+            int(typ.cast("typ.SupportsInt", result)) if result is not None else 0
+        )
         return (self.name, exit_code)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "ruff",
     "pyright",
     "pytest-timeout",
+    "pyyaml>=6.0.3",
 ]
 
 [tool.setuptools.packages.find]
@@ -135,6 +136,10 @@ typing = "typ"
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "subprocess.run".msg = "Use `plumbum` instead of `subprocess.run`"
 "subprocess.check_call".msg = "Use `plumbum` instead of `subprocess.check_call`"
+
+[tool.mutmut]
+source_paths = ["polythene/"]
+pytest_add_cli_args_test_selection = ["tests/"]
 
 [tool.pytest.ini_options]
 # Ensure asyncio fixtures create a new event loop for each test

--- a/tests/bdd/test_cli_behaviour.py
+++ b/tests/bdd/test_cli_behaviour.py
@@ -15,6 +15,14 @@ import polythene.isolation as isolation
 
 Context = dict[str, object]
 
+
+def _store_path(cli_context: Context) -> Path:
+    """Return the store recorded in ``cli_context`` as a ``Path``."""
+    store = cli_context["store"]
+    assert isinstance(store, Path), f"store must be a Path, got {type(store).__name__}"
+    return store
+
+
 scenarios("../features/polythene_cli.feature")
 
 
@@ -45,7 +53,7 @@ def clean_store(tmp_path: Path, cli_context: Context) -> Path:
 @given(parsers.parse('the rootfs "{uuid}" exists'))
 def ensure_rootfs(cli_context: Context, uuid: str) -> None:
     """Create a rootfs directory for ``uuid`` inside the store."""
-    store = Path(cli_context["store"])
+    store = _store_path(cli_context)
     (store / uuid).mkdir(parents=True, exist_ok=True)
 
 
@@ -102,7 +110,7 @@ def run_cli_command(
     cli_context: Context,
 ) -> None:
     """Invoke the CLI fixture with the formatted arguments."""
-    store = Path(cli_context["store"])
+    store = _store_path(cli_context)
     formatted = raw.format(store=store.as_posix())
     args = shlex.split(formatted)
     cli_context["result"] = run_cli(args)
@@ -115,7 +123,7 @@ def run_module_cli_command(
     cli_context: Context,
 ) -> None:
     """Invoke ``python -m polythene`` via the fixture with formatted args."""
-    store = Path(cli_context["store"])
+    store = _store_path(cli_context)
     formatted = raw.format(store=store.as_posix())
     args = shlex.split(formatted)
     cli_context["result"] = run_module_cli(args)
@@ -148,7 +156,7 @@ def assert_stderr_contains(cli_context: Context, value: str) -> None:
 @then(parsers.parse('the rootfs directory "{uuid}" exists'))
 def assert_rootfs_exists(cli_context: Context, uuid: str) -> None:
     """Ensure the exported rootfs folder exists on disk."""
-    store = Path(cli_context["store"])
+    store = _store_path(cli_context)
     assert (store / uuid).is_dir()
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -141,6 +141,7 @@ def test_make_prepare_bwrap_binds_context(
     assert "--tmpfs" in probe_cmd
     idx = probe_cmd.index("--tmpfs")
     assert probe_cmd[idx + 1] == str(context.container_tmp)
+    assert result is not None
     assert result[-2:] == ["-c", "echo hi"]
 
 
@@ -252,7 +253,10 @@ def test_probe_bwrap_userns_respects_sysctl(
     monkeypatch.setattr(backends, "_is_privileged_user", lambda: False)
 
     def fail_run_cmd(*_args: object, **_kwargs: object) -> typ.NoReturn:
-        pytest.fail("bubblewrap should not be probed when sysctl=0")
+        # ty misreads pytest.fail's decorated signature; the call is correct.
+        pytest.fail(
+            "bubblewrap should not be probed when sysctl=0"  # ty: ignore[invalid-argument-type]
+        )
         raise AssertionError("unreachable")  # appease Pyright's flow analysis
 
     monkeypatch.setattr(backends, "run_cmd", fail_run_cmd)

--- a/tests/test_polythene.py
+++ b/tests/test_polythene.py
@@ -110,7 +110,9 @@ class _DummyBackend:
 
 def test_normalise_command_args_flattens_single_sequence() -> None:
     """Internal helpers flatten nested command sequences."""
-    tokens = isolation._normalise_command_args((["echo", "hello"],))
+    tokens = isolation._normalise_command_args(
+        typ.cast("tuple[str, ...]", (["echo", "hello"],))
+    )
 
     assert tokens == ["echo", "hello"]
 
@@ -118,7 +120,7 @@ def test_normalise_command_args_flattens_single_sequence() -> None:
 def test_normalise_command_args_rejects_non_strings() -> None:
     """Non-string command tokens raise a descriptive ``TypeError``."""
     with pytest.raises(TypeError, match="Command tokens must be strings"):
-        isolation._normalise_command_args(((42,),))
+        isolation._normalise_command_args(typ.cast("tuple[str, ...]", ((42,),)))
 
 
 def test_cmd_exec_accepts_list_command(
@@ -133,7 +135,9 @@ def test_cmd_exec_accepts_list_command(
     monkeypatch.setattr(isolation, "BACKENDS", (backend,))
     monkeypatch.setattr(isolation, "IS_ROOT", True)
 
-    isolation.cmd_exec("uuid-list", ["echo", "hello world"], store=tmp_path)
+    isolation.cmd_exec(
+        "uuid-list", typ.cast("str", ["echo", "hello world"]), store=tmp_path
+    )
 
     assert backend.calls == [(root, "echo 'hello world'", None)]
 

--- a/tests/test_workflow_contract.py
+++ b/tests/test_workflow_contract.py
@@ -1,0 +1,152 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in the ``leynos/shared-actions`` reusable
+workflow, which carries its own unit and integration tests; polythene's
+caller is declarative configuration. These tests parse the caller with
+PyYAML and pin the contract it must uphold, so drift (repointing the
+pin at a branch, widening permissions, or losing the flat-layout
+configuration) fails CI on the pull request rather than surfacing in a
+scheduled or manual run.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "mutation-testing.yml"
+)
+
+#: The pinned commit of leynos/shared-actions. Bump the workflow and
+#: this test together.
+PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-mutmut.yml@" + PINNED_SHA
+)
+
+EXPECTED_WITH = {
+    "paths": "polythene/",
+    "module-prefix-strip": "",
+}
+
+
+def _as_mapping(value: object, message: str) -> dict[str, object]:
+    """Assert ``value`` is a mapping and narrow its type."""
+    assert isinstance(value, dict), message
+    return typ.cast("dict[str, object]", value)
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return _as_mapping(
+        yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8")),
+        "the workflow must be a YAML mapping",
+    )
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses the bare key as True)."""
+    raw = typ.cast("dict[object, object]", workflow)
+    return _as_mapping(
+        raw.get("on", raw.get(True)),
+        "the workflow must declare an on: mapping",
+    )
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = _as_mapping(workflow.get("jobs"), "the workflow must declare a jobs mapping")
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    return _as_mapping(jobs["mutation"], "jobs.mutation must be a mapping")
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the shared workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert isinstance(uses, str), "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-mutmut.yml", (
+        f"jobs.mutation.uses must reference mutation-mutmut.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
+        "bump the pin and this test together"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serialises_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _as_mapping(
+        _load().get("concurrency"), "the workflow must declare concurrency"
+    )
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch declares no inputs."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "50 5 * * *"}], (
+        f"on.schedule must be the daily 05:50 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = _as_mapping(
+        triggers.get("workflow_dispatch") or {},
+        "on.workflow_dispatch must be a mapping",
+    )
+    inputs = dispatch.get("inputs") or {}
+    assert not inputs, (
+        "on.workflow_dispatch must not declare inputs; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_flat_layout_configuration() -> None:
+    """The caller sets flat-layout paths and nothing else."""
+    with_block = _mutation_job(_load()).get("with")
+    assert with_block == EXPECTED_WITH, (
+        f"jobs.mutation.with must be exactly {EXPECTED_WITH!r}, got {with_block!r}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -249,6 +249,7 @@ dev = [
     { name = "polythene", extra = ["test"] },
     { name = "pyright" },
     { name = "pytest-timeout" },
+    { name = "pyyaml" },
     { name = "ruff" },
 ]
 
@@ -267,6 +268,7 @@ dev = [
     { name = "polythene", extras = ["test"] },
     { name = "pyright" },
     { name = "pytest-timeout" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff" },
 ]
 
@@ -352,6 +354,52 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a thin caller of the shared mutation-testing reusable workflow,
`leynos/shared-actions/.github/workflows/mutation-mutmut.yml`, pinned to
commit `47aea18960d24f33aedc4782ec6b73e365418313`. The job is
informational only and does not gate CI: the daily scheduled run (05:50
UTC) scopes mutation to modules changed in the last 25 hours, while a
manual `workflow_dispatch` run mutates the full package.

## Configuration for this repository

`[tool.mutmut]` in `pyproject.toml`:

```toml
[tool.mutmut]
source_paths = ["polythene/"]
pytest_add_cli_args_test_selection = ["tests/"]
```

- `source_paths = ["polythene/"]` — the package uses a flat layout
  (`polythene/` at the repository root), not src-layout.
- `pytest_add_cli_args_test_selection = ["tests/"]` — the entire suite,
  including the pytest-bdd behavioural tests and their feature files,
  lives under `tests/`, which mutmut copies wholesale into its working
  directory. There is no root `conftest.py` and no path-relative assets
  outside `tests/`, so no `also_copy` entries are required.
- No `do_not_mutate` entries: `polythene/unittests/` contains only a
  README (no Python), the CLI is exercised in-process by the test suite
  (via `polythene.app(...)` and `runpy.run_module`), and no product code
  runs in child processes during tests, so all mutants are attributable.

Caller `with:` block:

```yaml
with:
  paths: "polythene/"
  module-prefix-strip: ""
```

- `paths: "polythene/"` — change detection must match the flat-layout
  source prefix (the default is `src/`).
- `module-prefix-strip: ""` — there is no `src/` prefix to strip when
  translating changed files into module globs.

All other inputs keep their defaults.

A contract test (`tests/test_workflow_contract.py`) runs in the repo's
own pytest suite and pins the caller's contract: the exact commit SHA
(rejecting branch or tag refs), least-privilege permissions
(`contents: read`, `id-token: write`; top-level `{}`), per-ref
non-cancelling concurrency, the `50 5 * * *` schedule with a plain
dispatch trigger, and the exact `with:` block. PyYAML joins the `dev`
dependency group to support it.

## Validation

- `yaml.safe_load` parses the workflow; `actionlint` reports no issues.
- `uv run pytest tests/test_workflow_contract.py -q` — 6 passed.
- Negative test: repointing `uses:` at `@v1` fails the pin-guard test;
  restored, and the suite is green again.
- `uv run --with 'mutmut==3.6.0' mutmut results` runs without any
  configuration deprecation warnings (`source_paths` is the mutmut 3.6
  key, not the deprecated `paths_to_mutate`).
- `ruff check`/`ruff format --check` pass on the new test file, and
  `ty check` introduces no new diagnostics (the pre-existing baseline
  is unchanged).

## References

- Caller guide: <https://github.com/leynos/shared-actions/blob/main/docs/mutation-mutmut-workflow.md>
- Estate template: <https://github.com/leynos/wireframe/pull/572>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated mutation-testing workflow that can run on a daily schedule or be started manually.
  * Configured it to use a consistent, per-branch execution pattern and limited access permissions.
* **Tests**
  * Added contract tests to verify the workflow stays correctly configured over time.
* **Dependencies**
  * Added a new Python package needed for YAML-based workflow validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->