### PR TITLE
Align spelling helper with Weaver baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,8 @@ spelling-config: spelling-helper-test ## Generate and verify the spelling config
 	@$(TYPOS_CONFIG_BUILDER) --repository . --check
 
 spelling-helper-test: ## Validate the shared spelling-policy integration
-	@$(UV_ENV) $(UV) tool run ruff@$(RUFF_VERSION) format --isolated --target-version py314 --check $(SPELLING_PY_SRCS)
-	@$(UV_ENV) $(UV) tool run ruff@$(RUFF_VERSION) check --isolated --target-version py314 $(SPELLING_PY_SRCS)
+	@$(UV_ENV) $(UV) tool run ruff@$(RUFF_VERSION) format --isolated --target-version py313 --check $(SPELLING_PY_SRCS)
+	@$(UV_ENV) $(UV) tool run ruff@$(RUFF_VERSION) check --isolated --target-version py313 $(SPELLING_PY_SRCS)
 	@$(SPELLING_HELPER_PYTEST) $(SPELLING_PY_TESTS) -c /dev/null --rootdir=. -p no:cacheprovider $(SPELLING_COVERAGE_ARGS)
 
 nixie: $(NIXIE) ## Validate Mermaid diagrams

--- a/scripts/typos_rollout_check.py
+++ b/scripts/typos_rollout_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S uv run python
 # /// script
-# requires-python = ">=3.14"
+# requires-python = ">=3.13"
 # dependencies = ["pathspec==1.1.1"]
 # ///
 """Enforce exact phrase corrections alongside the Typos scanner."""
@@ -163,7 +163,7 @@ def check_phrase_corrections(
             continue
         try:
             text = (repository / relative).read_text(encoding="utf-8")
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
         masked = _masked(text, policy.ignore_patterns)
         found.extend(


### PR DESCRIPTION
## Summary

- declare the spelling helper compatible with Python 3.13
- use the approved Weaver Python 3.13 Ruff syntax policy
- retain explicit Python 3.14 execution in the spelling gate

## Validation

- Python 3.13 and explicit 3.14 helper tests: 3 passed at 95.45% coverage
- spelling config, build, format, lint, typecheck and 69 tests: passed
- Markdownlint, Nixie, Actionlint, six workflow contracts and composite validation: passed
- package sdist/wheel build, Twine check and isolated import smoke: passed
- generated spelling policy and dependency files: unchanged

The unchanged build-release global-module assumption, Checkmake PHONY false finding and existing tool warnings reproduce on clean main.
