### PR TITLE
Fix ty narrowing false positive in _table return type

### DIFF
--- a/scripts/typos_rollout_check.py
+++ b/scripts/typos_rollout_check.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import re
 import subprocess
 import tomllib
+import typing as typ
 
 from pathspec import GitIgnoreSpec
 
@@ -54,8 +55,10 @@ def _document(path: Path) -> dict[str, object]:
 
 def _table(document: dict[str, object], name: str) -> dict[str, object]:
     """Return a TOML table or an empty table when it is absent."""
-    value = document.get(name, {})
-    return value if isinstance(value, dict) else {}
+    value = document.get(name)
+    if isinstance(value, dict):
+        return typ.cast("dict[str, object]", value)
+    return {}
 
 
 def _strings(table: dict[str, object], key: str) -> tuple[str, ...]:


### PR DESCRIPTION
## Summary

- The `lint-test` required check on `main` currently fails `make typecheck`: an unpinned `ty` release started flagging `_table`'s `isinstance`-narrowed return as `Top[dict[Unknown, Unknown]]` rather than the declared `dict[str, object]`.
- This blocks unrelated pull requests (including a workflow-contract-test change) from getting a green required check.

## Review walkthrough

- `scripts/typos_rollout_check.py`: `_table` dropped the `{}` default from `document.get(name, ...)` (whose empty-dict literal was the source of the untyped `Top[dict[Unknown, Unknown]]`), narrows the resulting `object | None` with `isinstance`, and casts the confirmed mapping to the declared `dict[str, object]` before returning it — the same `typ.cast` idiom already used elsewhere in the codebase.
- No behavioural change: the function still returns the table when present and an empty dict otherwise.

## Validation

- `make typecheck` — was red on `main`, now passes.
- `make check-fmt`, `make lint`, `make spelling` — pass.
