### PR TITLE
Drop exact-SHA pin from workflow contract test

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,39 @@ project via the Makefile targets. Helpful commands include:
 
 Refer to the users' guide in `docs/users-guide.md` for deeper operational
 details and troubleshooting advice.
+
+### Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.

--- a/tests/test_workflow_contract.py
+++ b/tests/test_workflow_contract.py
@@ -3,14 +3,16 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests; polythene's
 caller is declarative configuration. These tests parse the caller with
-PyYAML and pin the contract it must uphold, so drift (repointing the
-pin at a branch, widening permissions, or losing the flat-layout
-configuration) fails CI on the pull request rather than surfacing in a
-scheduled or manual run.
+PyYAML and assert that it references the correct reusable workflow at a
+commit SHA, so drift (repointing the pin at a branch, widening
+permissions, or losing the flat-layout configuration) fails CI on the
+pull request rather than surfacing in a scheduled or manual run.
+Dependabot owns the pinned SHA value; these tests only pin its shape.
 """
 
 from __future__ import annotations
 
+import re
 import typing as typ
 from pathlib import Path
 
@@ -32,12 +34,8 @@ pytestmark = pytest.mark.skipif(
     ),
 )
 
-#: The pinned commit of leynos/shared-actions. Bump the workflow and
-#: this test together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-mutmut.yml@" + PINNED_SHA
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-mutmut\.yml@[0-9a-f]{40}$"
 )
 
 EXPECTED_WITH = {
@@ -79,25 +77,18 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return _as_mapping(jobs["mutation"], "jobs.mutation must be a mapping")
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must reference the correct path, pinned to a commit SHA.
+
+    The ref must be a full commit SHA, not a mutable branch or tag.
+    Dependabot owns the exact SHA value, so it is not asserted here.
+    """
     uses = _mutation_job(_load()).get("uses")
     assert isinstance(uses, str), "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-mutmut.yml", (
-        f"jobs.mutation.uses must reference mutation-mutmut.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump the pin and this test together"
+    assert USES_RE.match(uses), (
+        "jobs.mutation.uses must reference "
+        "leynos/shared-actions/.github/workflows/mutation-mutmut.yml "
+        f"pinned to a full 40-character lowercase hex commit SHA, got {uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- The mutation-testing workflow contract test pinned the exact `leynos/shared-actions` commit SHA (`test_uses_reference_is_pinned_to_the_documented_sha`), so every Dependabot bump of the caller failed CI until a human hand-edited the `PINNED_SHA` constant.
- This hands SHA ownership to Dependabot while keeping the structural contract: the caller must still reference the correct reusable workflow, pinned to a full commit SHA (not a mutable branch or tag).

## Review walkthrough

- `tests/test_workflow_contract.py`:
  - Replaced the `PINNED_SHA` / `EXPECTED_USES` constants and the exact-equality assertion with a `USES_RE` regex that matches `leynos/shared-actions/.github/workflows/mutation-mutmut.yml@<40-hex-sha>` and anchors on both ends. It confirms the path and that the ref is a full 40-character lowercase hex SHA, without asserting which SHA.
  - Renamed the test to `test_uses_reference_is_pinned_to_a_commit_sha` and updated the module docstring: it no longer claims to pin the SHA; it now states Dependabot owns the SHA value.
  - All other assertions (permissions, default token scope, concurrency, triggers, `with` inputs) are unchanged, as is the `skipif` guard for mutmut's sandbox.
- `README.md`: added a "Workflow pins and Dependabot" subsection under the development workflow documenting the policy for future contract tests.
- No workflow files touched; the caller's actual pin is untouched, so Dependabot owns it from here.

## Validation

- `make test` — the six contract tests pass against today's pinned SHA; the regex also matches any other 40-hex SHA and rejects branch/tag refs (verified out of band).
- `make typecheck`, `make lint`, `make check-fmt`, `make spelling` — pass.
- `.github/dependabot.yml` already has a `github-actions` entry with `directory: "/"` (weekly), which updates reusable-workflow `uses:` refs; no change needed.
