### PR TITLE
Fix duplicate CliResult identity in mutmut sandbox (#36)

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+"""Test package for Polythene.
+
+Making ``tests`` a real package (rather than relying on pytest's rootdir
+path-insertion for directories without ``__init__.py``) gives every test
+module a single, unambiguous dotted import path such as
+``tests.support.cli``. See ``tests/support/__init__.py`` for why this
+matters for mutmut's sandboxed test runs.
+"""
+
+from __future__ import annotations

--- a/tests/bdd/__init__.py
+++ b/tests/bdd/__init__.py
@@ -1,0 +1,3 @@
+"""BDD test package for Polythene."""
+
+from __future__ import annotations

--- a/tests/bdd/test_cli_behaviour.py
+++ b/tests/bdd/test_cli_behaviour.py
@@ -7,11 +7,11 @@ import typing as typ
 from pathlib import Path
 
 import pytest
-from conftest import CliResult
 from pytest_bdd import given, parsers, scenarios, then, when
 
 import polythene.backends as backend_module
 import polythene.isolation as isolation
+from tests.support.cli import CliResult
 
 Context = dict[str, object]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import dataclasses as dc
 import sys
 import typing as typ
 from contextlib import redirect_stderr, redirect_stdout
@@ -12,15 +11,9 @@ from runpy import run_module
 import pytest
 
 import polythene
+from tests.support.cli import CliResult
 
-
-@dc.dataclass(slots=True)
-class CliResult:
-    """Container capturing CLI output and exit status."""
-
-    exit_code: int
-    stdout: str
-    stderr: str
+__all__ = ["CliResult", "run_cli", "run_module_cli"]
 
 
 @pytest.fixture

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -1,0 +1,13 @@
+"""Shared test-support helpers imported by name via ``tests.support``.
+
+Keeping these helpers in a real, importable package (rather than defining
+them in ``conftest.py``) ensures every consumer resolves the same module
+object. ``conftest.py`` files are collected specially by pytest, and a bare
+``from conftest import X`` performed by a test module can end up importing a
+*second*, distinct copy of ``conftest`` under some sandboxing/import-mode
+combinations (notably mutmut's isolated test run). That produces classes
+that are structurally identical yet fail ``isinstance`` checks against each
+other. Routing all imports through ``tests.support`` avoids the ambiguity.
+"""
+
+from __future__ import annotations

--- a/tests/support/cli.py
+++ b/tests/support/cli.py
@@ -1,0 +1,21 @@
+"""CLI result type shared by fixtures and BDD assertions.
+
+This lives outside ``conftest.py`` so every consumer imports it via the
+single canonical path ``tests.support.cli``, regardless of whether the
+consumer is a fixture defined in a ``conftest.py`` or a step/assertion
+defined in a BDD test module. See ``tests/support/__init__.py`` for the
+rationale.
+"""
+
+from __future__ import annotations
+
+import dataclasses as dc
+
+
+@dc.dataclass(slots=True)
+class CliResult:
+    """Container capturing CLI output and exit status."""
+
+    exit_code: int
+    stdout: str
+    stderr: str

--- a/tests/test_polythene.py
+++ b/tests/test_polythene.py
@@ -14,7 +14,7 @@ from polythene import backends
 if typ.TYPE_CHECKING:
     from pathlib import Path
 
-    from conftest import CliResult
+    from tests.support.cli import CliResult
 
 
 def test_cmd_pull_exports_rootfs(


### PR DESCRIPTION
## Summary

- Fixes a mutmut-sandbox-only baseline failure in the BDD CLI suite: `isinstance(result, CliResult)` returned `False` even though the repr matched exactly (`tests/bdd/test_cli_behaviour.py::test_executing_with_a_missing_rootfs`, scheduled run [29397719725](https://github.com/leynos/polythene/actions/runs/29397719725)).
- Root cause: `tests/bdd/test_cli_behaviour.py` did a bare `from conftest import CliResult`. With no `tests/__init__.py`, pytest's rootdir-relative path insertion let `conftest.py` be imported under a second, independent module identity from the one pytest's own conftest-collection machinery uses. Under mutmut's isolated sandbox this produced two distinct `CliResult` class objects — structurally identical, but `isinstance` treats them as unrelated.
- Fix: move `CliResult` out of `conftest.py` into a real importable module, `tests/support/cli.py`, and make `tests` a proper package (`tests/__init__.py`, `tests/bdd/__init__.py`, `tests/support/__init__.py`). `tests/conftest.py`, `tests/bdd/test_cli_behaviour.py`, and `tests/test_polythene.py` (a `TYPE_CHECKING`-only reference) now all import `CliResult` via the single canonical dotted path `tests.support.cli`, so there is exactly one module object backing that name regardless of collection order or sandboxing.
- No `also_copy` entry is needed: the new module lives under `tests/`, which is already covered by the mutmut config's `pytest_add_cli_args_test_selection = ["tests/"]` and gets copied into the sandbox as part of the existing test tree.

Closes #36

## Why this is a genuine repo-side fix (not just a shared-actions workaround)

The issue notes that `leynos/shared-actions` PR #344 (merged 2026-07-18, relocating `workflow-src` out of the caller's workspace during mutation runs) may have contributed to triggering this failure, since tree pollution can perturb Python's module/path resolution during collection. That may well have been a contributing factor for the specific failure seen in run 29397719725. However, the dual-module-identity hazard is a genuine fragility in this repository regardless: any bare `from conftest import X` in a test module, combined with `tests/` lacking `__init__.py`, is one sandboxing/import-mode quirk away from importing two copies of the same file under different identities. This PR removes that hazard at the source rather than relying on the caller-side ordering fix to paper over it.

## Review walkthrough

- [`tests/support/cli.py`](https://github.com/leynos/polythene/blob/fix/mutmut-module-identity/tests/support/cli.py) — new home for `CliResult`, with a comment explaining why it lives here.
- [`tests/support/__init__.py`](https://github.com/leynos/polythene/blob/fix/mutmut-module-identity/tests/support/__init__.py) — package marker with the rationale for the restructure.
- [`tests/__init__.py`](https://github.com/leynos/polythene/blob/fix/mutmut-module-identity/tests/__init__.py), [`tests/bdd/__init__.py`](https://github.com/leynos/polythene/blob/fix/mutmut-module-identity/tests/bdd/__init__.py) — make `tests` and `tests.bdd` real packages so every test module resolves via the repo root, giving `tests.support.cli` one unambiguous identity.
- [`tests/conftest.py`](https://github.com/leynos/polythene/blob/fix/mutmut-module-identity/tests/conftest.py) — imports `CliResult` from `tests.support.cli` instead of defining it locally; fixtures unchanged.
- [`tests/bdd/test_cli_behaviour.py`](https://github.com/leynos/polythene/blob/fix/mutmut-module-identity/tests/bdd/test_cli_behaviour.py) — replaces `from conftest import CliResult` with `from tests.support.cli import CliResult`.
- [`tests/test_polythene.py`](https://github.com/leynos/polythene/blob/fix/mutmut-module-identity/tests/test_polythene.py) — updates the `TYPE_CHECKING`-only import for consistency (no runtime behaviour change there, but avoids a second stale import path).

## Validation evidence

- Red: reproduced the sandbox failure the way mutmut actually runs it, `uv run --with mutmut==3.6.0 mutmut run` against the pre-fix tree — baseline failed immediately with `1 failed, 1 warning`, `AssertionError: assert False  +  where False = isinstance(CliResult(...), CliResult)`, `Failed to run clean test`, `mutmut_error=mutmut run failed with exit code 1`.
- Green: same command against the fixed tree — the unmutated baseline passes and the run proceeds through the full mutation sweep (530/530 mutants processed) without the clean-test failure.
- `uv run pytest -q`: 69 passed.
- `make check-fmt`, `make lint`, `make typecheck`, `make test`: all green.

## Test plan

- [x] Reproduce the mutmut baseline failure pre-fix
- [x] Confirm the same command runs clean post-fix
- [x] `uv run pytest -q` passes locally
- [x] `make check-fmt` / `make lint` / `make typecheck` / `make test` pass
- [ ] CI green on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test package organization with stable import paths.
  * Added shared utilities for capturing command-line results, including exit codes and output streams.
  * Updated CLI and application tests to use the centralized test helpers.
  * Preserved existing test behavior while improving consistency across test modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->