### PR TITLE
Document Python docstring conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,25 @@
   Group related code (e.g., models + utilities + fixtures) close together.
 - **Group by feature, not layer.** Colocate views, logic, fixtures, and helpers
   related to a domain concept rather than splitting by type.
+- **Document public APIs comprehensively.** Public functions, classes, and
+  methods must have comprehensive NumPy-style docstrings, including clear
+  examples that demonstrate usage and outcome where appropriate.
+- **Keep private helper docstrings concise.** Prefer single-line docstrings for
+  private helpers. When a private helper needs an explanatory paragraph,
+  inspect whether that need exposes conflated responsibilities, an unclear
+  command/query boundary, or another CQRS or cohesion failure:
+  - Split the helper when it performs distinct query and command
+    responsibilities or combines unrelated concerns.
+  - Extract a focused helper when doing so makes the invariant or boundary
+    local and simpler.
+  - Keep the helper intact when its responsibility is cohesive and the
+    explanation documents an unavoidable local constraint; retain the
+    paragraph in that case.
+- **Structure private helper docstrings selectively.** Use structured
+  NumPy-style sections for private helpers only when they describe non-obvious
+  behaviour.
+- **Keep test documentation meaningful.** Test documentation should omit
+  examples that only restate the test logic.
 
 ## Documentation Maintenance
 


### PR DESCRIPTION
## Summary

This change adds the canonical Python docstring conventions to [AGENTS.md](https://github.com/leynos/polythene/blob/452200fae7e5c5c33fafcce3feb5294e2c8af2fe/AGENTS.md). It makes the public-API scope explicit, keeps private helper documentation concise by default, and describes when longer helper documentation should prompt a CQRS or cohesion review.

## Validation

- `make fmt`
- `make markdownlint`
- `make nixie`
- Confirmed the remote branch matches `452200fae7e5c5c33fafcce3feb5294e2c8af2fe`
- Confirmed the worktree is clean

## References

- https://lody.ai/leynos/sessions/a6c2af8d-bb01-4dca-8060-3c08dffb5d50

## Summary by Sourcery

Document and clarify Python docstring conventions for public APIs, private helpers, and tests in AGENTS.md.

Documentation:
- Add guidance that public Python APIs must use comprehensive NumPy-style docstrings with examples where appropriate.
- Describe expectations for concise docstrings on private helpers and how they relate to CQRS and cohesion reviews when longer explanations are needed.
- Clarify when to use structured NumPy-style sections for private helpers and how to keep test documentation focused and meaningful.